### PR TITLE
Adds .rodata section when converting elf to hex.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(OUT).elf: $(OBJ)
 
 $(OUT).hex: $(OUT).elf
 	rm -f $(OUT).hex $(OUT).eep.hex
-	$(OBJCOPY) -j .text -j .data -O ihex $(OUT).elf $(OUT).hex
+	$(OBJCOPY) -j .text -j .data -j .rodata -O ihex $(OUT).elf $(OUT).hex
 	$(SIZE) $(OUT).hex
 
 # debugging targets:


### PR DESCRIPTION
Fixes issues with strings being uninitialized.

https://stackoverflow.com/questions/76742658/sending-mutiple-characters-using-usart1-on-an-atmega4809-results-in-0xff-to-be-s